### PR TITLE
Add Pull Request template w/ common PR conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Description
+
+<!-- Write a brief description of the changes introduced by this PR -->
+
+### Testing Methodologies
+
+<!-- Describe how you tested your changes and ensured they provide expected behavior -->
+
+### Related Issue(s)
+
+<!-- 
+Does this issue fix a known bug? If so, great!
+For issues this PR will RESOLVE, write "Fixes #<issue_number_here>".
+For issues this PR is RELATED TO, write "Related to #<issue_number_here>".
+-->


### PR DESCRIPTION
I know Issue Templates provide parsing of YAML front matter to automatically label, name, and assign issues as needed, but could not find any evidence of equivalent behavior for pull request templates. (This would be a cool feature to request of GitHub imo.) For most repositories I've seen, bots provide the automated labeling & review request functionality.